### PR TITLE
Adding re-injection support for Lists and Maps

### DIFF
--- a/src/main/java/org/springframework/reinject/ReInjectFactoryBean.java
+++ b/src/main/java/org/springframework/reinject/ReInjectFactoryBean.java
@@ -1,5 +1,8 @@
 package org.springframework.reinject;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.ApplicationContext;
@@ -38,4 +41,18 @@ class ReInjectFactoryBean implements FactoryBean, ApplicationContextAware {
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }
+    
+    /**
+     * Stub implementation to allow re-injecting maps
+     */
+    public void setSourceMap(Map<?, ?> sourceMap) {
+		// no-op
+	}
+    
+    /**
+     * Stub implementation to allow re-injecting lists
+     */
+    public void setSourceList(List<?> sourceList) {
+		// no-op
+	}
 }

--- a/src/test/java/org/springframework/reinject/InjectListTest.java
+++ b/src/test/java/org/springframework/reinject/InjectListTest.java
@@ -1,0 +1,46 @@
+package org.springframework.reinject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import junit.framework.Assert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@DirtiesContext
+public class InjectListTest {
+	
+	private static final String BEAN_NAME = "stringList";
+
+	private static final String STUB_ENTRY_1 = "Mesa list entry 1";
+
+	@Autowired
+	private ApplicationContext applicationContext;
+	
+	private List<String> listStub = new ArrayList<>();
+	
+	public InjectListTest() {
+		listStub.add(STUB_ENTRY_1);
+		ReInjectPostProcessor.inject(BEAN_NAME, List.class, listStub);
+	}
+	
+	@Test
+	public void testInjectMap() throws Exception {
+		@SuppressWarnings("unchecked")
+		List<String> actualList = (List<String>) applicationContext.getBean(BEAN_NAME);
+		Assert.assertEquals("Empty list should have been reinjected!", 1,  actualList.size());
+		String actual = actualList.get(0);
+		String expected = STUB_ENTRY_1;
+		Assert.assertEquals(expected, actual);
+	}
+
+}

--- a/src/test/java/org/springframework/reinject/InjectMapTest.java
+++ b/src/test/java/org/springframework/reinject/InjectMapTest.java
@@ -1,0 +1,46 @@
+package org.springframework.reinject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import junit.framework.Assert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@DirtiesContext
+public class InjectMapTest {
+	
+	private static final String BEAN_NAME = "stringStringMap";
+
+	private static final String STUB_KEY_1 = "MESA.KEY";
+
+	private static final String STUB_VALUE_1 = "JarJar says hello";
+
+	@Autowired
+	private ApplicationContext applicationContext;
+	
+	private Map<String, String> mapStub = new HashMap<>();
+	
+	public InjectMapTest() {
+		mapStub.put(STUB_KEY_1, STUB_VALUE_1);
+		ReInjectPostProcessor.inject(BEAN_NAME, Map.class, mapStub);
+	}
+	
+	@Test
+	public void testInjectMap() throws Exception {
+		@SuppressWarnings("unchecked")
+		Map<String, String> actualMap = (Map<String, String>) applicationContext.getBean(BEAN_NAME);
+		String actual = actualMap.get(STUB_KEY_1);
+		String expected = STUB_VALUE_1;
+		Assert.assertEquals(expected, actual);
+	}
+
+}

--- a/src/test/resources/org/springframework/reinject/InjectListTest-context.xml
+++ b/src/test/resources/org/springframework/reinject/InjectListTest-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
+
+    <bean class="org.springframework.reinject.ReInjectPostProcessor"/>
+    
+    <util:list id="stringList" />
+</beans>
+

--- a/src/test/resources/org/springframework/reinject/InjectMapTest-context.xml
+++ b/src/test/resources/org/springframework/reinject/InjectMapTest-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
+
+    <bean class="org.springframework.reinject.ReInjectPostProcessor"/>
+    
+    <util:map id="stringStringMap" />
+</beans>
+


### PR DESCRIPTION
Hit some stack traces today trying to re-inject Maps and Lists! Added the missing methods to the `ReInjectFactoryBean` and it seems to be be working properly now. JUnit tested.

Not sure if the no-op stub implementations i've used are best practice, though, so i'd be open to suggestions!
